### PR TITLE
set default quite option for get_file to xpdb value

### DIFF
--- a/R/xpdb_access.R
+++ b/R/xpdb_access.R
@@ -136,8 +136,9 @@ get_data <- function(xpdb, table = NULL, problem = NULL) {
 #' print(xpdb_ex_pk)
 #' 
 #' @export
-get_file <- function(xpdb, file = NULL, ext = NULL, problem = NULL, subprob = NULL, quiet = FALSE) {
+get_file <- function(xpdb, file = NULL, ext = NULL, problem = NULL, subprob = NULL, quiet) {
   check_xpdb(xpdb, check = 'files')
+  if (missing(quiet)) quiet <- xpdb$options$quiet
   
   if (is.null(file) && is.null(ext)) {
     stop('Argument `file` or `ext` required.', call. = FALSE) 

--- a/tests/testthat/test-xpdb_access.R
+++ b/tests/testthat/test-xpdb_access.R
@@ -82,6 +82,12 @@ test_that("get_file works properly", {
                              `run001.phi` = xpdb_ex_pk$files[xpdb_ex_pk$files$name == 'run001.phi', ]$data[[1]]))
 })
 
+test_that("get_file is quite when option is set in xpdb", {
+  # ensure option is set
+  xpdb_ex_pk$options$quiet <- TRUE
+  expect_silent(get_file(xpdb_ex_pk, file = 'run001.ext'))
+})
+
 
 # Tests for get_summary ---------------------------------------------------
 test_that("get_summary checks input properly", {


### PR DESCRIPTION
In contrast to the plotting function, the quite option for get_file was not taken from the xpdb. Just made this consistent and added a test to ensure that this works in the future.