### PR TITLE
plots: added check_plot_type to warn for improper plot type input

### DIFF
--- a/R/plot_vpc.R
+++ b/R/plot_vpc.R
@@ -104,6 +104,9 @@ vpc <- function(xpdb,
             call. = FALSE)}
   }
   
+  # Check type
+  check_plot_type(type, allowed = c('a', 'p', 'l', 'r', 't'))
+  
   # Assing xp_theme and gg_theme
   if (!missing(xp_theme)) {
     xpdb <- update_themes(xpdb = xpdb, xp_theme = xp_theme)

--- a/R/xplot_distrib.R
+++ b/R/xplot_distrib.R
@@ -60,6 +60,9 @@ xplot_distrib <- function(xpdb,
          call. = FALSE)
   }
   
+  # Check type
+  check_plot_type(type, allowed = c('h', 'd', 'r'))
+  
   # Assing xp_theme and gg_theme
   if (!missing(xp_theme)) xpdb <- update_themes(xpdb = xpdb, xp_theme = xp_theme)
   if (missing(gg_theme)) gg_theme <- xpdb$gg_theme

--- a/R/xplot_helpers.R
+++ b/R/xplot_helpers.R
@@ -15,6 +15,16 @@ check_xpdb <- function(xpdb, check = 'data') {
   }
 }
 
+# Check plot type
+check_plot_type <- function(user_input, allowed) {
+  user_input  <- stringr::str_extract_all(user_input, pattern = '.')[[1]]
+  not_allowed <- user_input[!user_input %in% allowed]
+  if (length(not_allowed) > 0) {
+    warning('Plot type ', stringr::str_c('"',not_allowed, '"', collapse = ', '), 
+         ' not recognized.', call. = FALSE)
+  }
+}
+
 # Check plot scales
 check_scales <- function(scale, log) {
   if (is.null(log)) return('continuous')

--- a/R/xplot_qq.R
+++ b/R/xplot_qq.R
@@ -54,6 +54,9 @@ xplot_qq <- function(xpdb,
          call. = FALSE)
   }
   
+  # Check type
+  check_plot_type(type, allowed = 'p')
+  
   # Assing xp_theme and gg_theme
   if (!missing(xp_theme)) xpdb <- update_themes(xpdb = xpdb, xp_theme = xp_theme)
   if (missing(gg_theme)) gg_theme <- xpdb$gg_theme

--- a/R/xplot_scatter.R
+++ b/R/xplot_scatter.R
@@ -83,6 +83,9 @@ xplot_scatter <- function(xpdb,
          call. = FALSE)
   }
   
+  # Check type
+  check_plot_type(type, allowed = c('p', 'l', 's', 't'))
+  
   # Assing xp_theme and gg_theme
   if (!missing(xp_theme)) xpdb <- update_themes(xpdb = xpdb, xp_theme = xp_theme)
   if (missing(gg_theme)) gg_theme <- xpdb$gg_theme

--- a/tests/testthat/test-xplot_helpers.R
+++ b/tests/testthat/test-xplot_helpers.R
@@ -80,3 +80,11 @@ test_that('Check check_xpdb', {
   expect_null(check_xpdb(xpdb_NULL, check = FALSE))
   expect_null(check_xpdb(xpdb_ex_pk, check = 'data'))
 })
+
+test_that('Check check_plot_type', {
+  expect_silent(check_plot_type('pls', allowed = c('p', 'l', 's', 't')))
+  expect_warning(check_plot_type('prlst', allowed = c('p', 'l', 's', 't')), 
+                 regexp = 'Plot type \"r\" not recognized')
+  expect_warning(check_plot_type('prsz', allowed = c('p', 'l', 's', 't')), 
+                 regexp = 'Plot type \"r\", \"z\" not recognized')
+})


### PR DESCRIPTION
- Users will now be warned when `type =` contains unrecognized character type.