### PR TITLE
Change detection of ETA in read_nm_tables index_table function to rem…

### DIFF
--- a/R/read_nm_tables.R
+++ b/R/read_nm_tables.R
@@ -375,7 +375,7 @@ index_table <- function(x) {
       .$col == 'IPRED' ~ 'ipred',
       .$col == 'PRED' ~ 'pred',
       .$col %in% c('RES', 'WRES', 'CWRES', 'IWRES', 'EWRES', 'NPDE') ~ 'res',
-      stringr::str_detect(.$col, 'ETA\\d+|ET\\d+') ~ 'eta',
+      stringr::str_detect(.$col, '^ETA|^ET') ~ 'eta',
       stringr::str_detect(.$col, '^A\\d+$') ~ 'a',
       TRUE ~ tab_type))
 }


### PR DESCRIPTION
…ove digits and search from start of column name. Allows detection of variables like ETA_CL and ETA_V as type "eta". Closes #112 

Question: Is it OK to assume that the "ETA" or "ET" comes at the *start* of the variable name?