### PR TITLE
fixed typo in vpc_opt

### DIFF
--- a/man/vpc_opt.Rd
+++ b/man/vpc_opt.Rd
@@ -24,9 +24,9 @@ timepoints (default) or 'middle' to use the average of the bin boundaries.}
 
 \item{pred_corr_lower_bnd}{Option reserved to continuous VPC. Lower bound for the prediction-correction.}
 
-\item{pi}{Option reserved to continuous VPC. Simulated prediction interval to plot. Default is c(0.05, 0.95).}
+\item{pi}{Option reserved to continuous VPC. Simulated prediction interval to plot. Default is c(0.025, 0.975).}
 
-\item{ci}{Confidence interval around the percentiles to plot. Default is c(0.05, 0.95)}
+\item{ci}{Confidence interval around the percentiles to plot. Default is c(0.025, 0.975)}
 
 \item{lloq}{Number or NULL indicating lower limit of quantification. Default is NULL.}
 


### PR DESCRIPTION
Defaults for pi & ci were incorrectly defined as 0.5 & 0.95, when they are actually 0.25 & 0.975. Changed text to reflect the true default values.