### PR TITLE
Allow assignment into xpose_data class without conversion to uneval

### DIFF
--- a/R/xpose_data.R
+++ b/R/xpose_data.R
@@ -169,4 +169,10 @@ xpose_data <- function(runno         = NULL,
     structure(class = c('xpose_data', 'uneval'))
 }
 
-
+#' Allow assignment into xpose_data without conversion to class uneval
+`[[<-.xpose_data` <- function(x, i, value) {
+  x <- unclass(x)
+  x[[i]] <- value
+  as.xpdb(x)
+}
+`$<-.xpose_data` <- `[[<-.xpose_data`


### PR DESCRIPTION
Allow assignment into the xpose_data class without conversion to an uneval class.  (This is the change I intended to send in the last PR.)