### PR TITLE
Improve detection of off-diagonal omega names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# xpose 0.4.4.9000
+### General
+* Off-diagonal ETA names are better-detected (@billdenney #121)
+
 # xpose 0.4.4
 ### General
 * Improved documentation for `xpose_data` (@billdenney #99)

--- a/R/xpdb_access.R
+++ b/R/xpdb_access.R
@@ -423,13 +423,23 @@ get_prm <- function(xpdb,
       }
       
       # Assign OMEGA labels
-      n_omega     <- sum(prms$type == 'ome' & prms$diagonal, na.rm = TRUE)
+      mask_omega <- prms$type == 'ome' & prms$diagonal
+      mask_omega_all <-
+        prms$type == 'ome' &
+        !is.nan(prms$value) &
+        (prms$diagonal |
+           !(prms$value == 0 & prms$fixed & !prms$diagonal)
+        )
+      n_omega     <- sum(mask_omega, na.rm = TRUE)
+      n_omega_all <- sum(mask_omega_all, na.rm = TRUE)
       omega_names <- data$prm_names$omega
-      if (n_omega != length(omega_names)) {
+      if (n_omega == length(omega_names)) {
+        prms$label[mask_omega] <- omega_names
+      } else if (n_omega_all == length(omega_names)) {
+        prms$label[mask_omega_all] <- omega_names
+      } else {
         warning('[$prob no.', data$problem, ', subprob no.', data$subprob, ', ', data$method, 
                 '] $OMEGA labels did not match the number of OMEGAs in the `.ext` file.', call. = FALSE)
-      } else {
-        prms$label[prms$type == 'ome' & prms$diagonal] <- omega_names
       }
       
       # Assign SIGMA labels


### PR DESCRIPTION
While I don't think it's the perfect solution, this fixes #121 for me. I think that a better parser (which is in the works) is a better long-term solution so that omega names and labels are automatically linked at parsing of the .lst file.

This replaces the PR in #146.