### PR TITLE
Fix test case for readr 2.0.0

### DIFF
--- a/tests/testthat/test-read_nm_tables.R
+++ b/tests/testthat/test-read_nm_tables.R
@@ -94,12 +94,12 @@ test_that('properly pick up column signs', {
   on.exit(unlink(files))
   writeLines(text = minus_sign_test, con = files)
   
-  # Positive control with readr (reproducible bug example)
-  expect_false(min(readr::read_table(file = files, skip = 2, guess_max = 1,
-                                     col_names = c('ID', 'TIME', 'DV'))$DV) == -5)
-  
   # Text on xpose
   expect_true(min(read_nm_tables(file = files, quiet = TRUE, 
                                  guess_max = 1, skip = 2)$DV) == -5)
+  
+  # Positive control with readr (reproducible bug example)
+  expect_false(min(readr::read_fwf(file = files, skip = 2,
+                                   col_positions = fwf_empty(files, skip = 2, n = 1, col_names = c('ID', 'TIME', 'DV')))$DV) == -5)
   })
 

--- a/tests/testthat/test-read_nm_tables.R
+++ b/tests/testthat/test-read_nm_tables.R
@@ -100,6 +100,6 @@ test_that('properly pick up column signs', {
   
   # Positive control with readr (reproducible bug example)
   expect_false(min(readr::read_fwf(file = files, skip = 2,
-                                   col_positions = fwf_empty(files, skip = 2, n = 1, col_names = c('ID', 'TIME', 'DV')))$DV) == -5)
+                                   col_positions = readr::fwf_empty(files, skip = 2, n = 1, col_names = c('ID', 'TIME', 'DV')))$DV) == -5)
   })
 


### PR DESCRIPTION
In readr 2.0.0 `read_table2()` has been renamed to `read_table()`, as
most users expect `read_table()` to work like `utils::read.table()`.

This breaks the test, as the `read_table2()` properly interprets the
minus sign.

We restored the positive control by using `read_fwf()` and `fwf_empty()` in
place of `read_table()`

We plan to submit readr 2.0.0 to cran in 2-4 weeks, so you will need to submit your package with these changes before then to avoid breaking tests on CRAN.