### PR TITLE
Fix for dev stringr

### DIFF
--- a/R/xplot_helpers.R
+++ b/R/xplot_helpers.R
@@ -95,7 +95,7 @@ check_scales <- function(scale, log) {
 #' @export
 append_suffix <- function(xpdb, string = NULL, type = NULL) {
   if (is.null(string)) return()
-  stringr::str_c(string, xpdb$xp_theme[stringr::str_c(type, '_suffix')], sep = '')
+  stringr::str_c(string, xpdb$xp_theme[[stringr::str_c(type, '_suffix')]], sep = '')
 }
 
 


### PR DESCRIPTION
stringr now requires that you give it strings. `xpdb$xp_theme[]` returns a length-1 uneval object; `xpdb$xp_theme[[]]` returns a string.