### PR TITLE
Don't summarise RANMETHOD as an estimation method

### DIFF
--- a/R/summarise_nm_model.R
+++ b/R/summarise_nm_model.R
@@ -509,12 +509,12 @@ sum_method <- function(model, software) {
   if (software == 'nonmem') {
     x <- model %>% 
       dplyr::filter(.$subroutine %in% c('sim', 'est')) %>% 
-      dplyr::filter(stringr::str_detect(.$code, 'METH|NSUB'))
+      dplyr::filter(stringr::str_detect(.$code, '(?<!RAN)METH|NSUB'))
     
     if (nrow(x) == 0) return(sum_tpl('method', 'na'))
     
     x %>% 
-      dplyr::mutate(value = stringr::str_match(.$code, 'METH[OD]*\\s*=\\s*([^\\s]+)')[, 2],
+      dplyr::mutate(value = stringr::str_match(.$code, '(?<!RAN)METH[OD]*\\s*=\\s*([^\\s]+)')[, 2],
                     inter = stringr::str_detect(.$code, '\\sINTER'),
                     lapl  = stringr::str_detect(.$code, '\\sLAPLA'),
                     like  = stringr::str_detect(.$code, '\\sLIKE')) %>% 


### PR DESCRIPTION
If you had a RANMETHOD option on a separate row (making it the first occurence of a "METH" regexp-match on that row), xpose would treat it as an estimation method (eg method = 3sp2p). With the updated regexp, xpose now matches only "METH" strings that are not preceded by "RAN", thus solving the issue.