### PR TITLE
Correct sensitivity of irep() to sort order

### DIFF
--- a/R/xpdb_edits.R
+++ b/R/xpdb_edits.R
@@ -364,8 +364,12 @@ check_quo_vars <- function(xpdb, ..., .source, .problem) {
 irep <- function(x, quiet = FALSE) {
   if (missing(x)) stop('argument "x" is missing, with no default', call. = FALSE)
   if (is.factor(x)) x <- as.numeric(as.character(x))
-  x <- dplyr::if_else(dplyr::lag(x, default = x[1]) > x, 1, 0)
-  x <- cumsum(x) + 1
+  lagcheck <- dplyr::lag(x, default = x[1]) != x
+  dupcheck <- duplicated(x)
+  check <- dplyr::if_else(lagcheck & dupcheck, 1, 0)
+  ilen <- which(check==1)[1] - 1
+  if (is.na(ilen)) ilen <- length(x)
+  x <- rep(1:(length(x)/ilen), each=ilen)
   msg(c('irep: ', max(x), ' simulations found.'), quiet)
   x
 }


### PR DESCRIPTION
The current irep() depends upon the input x already being sorted within each repeat, but NONMEM does not have this requirement. The proposed change works whether or not x is sorted this way.

``` r
library(xpose)
#> Loading required package: ggplot2
#> Warning: package 'ggplot2' was built under R version 4.2.3
#> 
#> Attaching package: 'xpose'
#> The following object is masked from 'package:stats':
#> 
#>     filter

irep2 <- function(x, quiet = FALSE) {
  if (missing(x)) stop('argument "x" is missing, with no default', call. = FALSE)
  if (is.factor(x)) x <- as.numeric(as.character(x))
  lagcheck <- dplyr::lag(x, default = x[1]) != x
  dupcheck <- duplicated(x)
  check <- dplyr::if_else(lagcheck & dupcheck, 1, 0)
  ilen <- which(check==1)[1] - 1
  if (is.na(ilen)) ilen <- length(x)
  x <- rep(1:(length(x)/ilen), each=ilen)
  msg(c('irep: ', max(x), ' simulations found.'), quiet)
  x
}

reps <- 15

sorted <- rep(c(1,1,1,2,2,2,2,3,3,3),reps)
unsorted <- rep(c(10,10,10,2,2,2,2,3,3,3),reps)

max(irep(sorted))==reps
#> irep: 15 simulations found.
#> [1] TRUE
max(irep(unsorted))==reps
#> irep: 16 simulations found.
#> [1] FALSE

max(irep2(sorted))==reps
#> irep: 15 simulations found.
#> [1] TRUE
max(irep2(unsorted))==reps
#> irep: 15 simulations found.
#> [1] TRUE
```

<sup>Created on 2024-06-24 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
