### PR TITLE
Omit special handling for readr <2.0.0

### DIFF
--- a/R/read_nm_tables.R
+++ b/R/read_nm_tables.R
@@ -269,15 +269,9 @@ read_nm_tables <- function(file          = NULL,
 #' @keywords internal
 #' @export
 read_funs <- function(fun) {
-  if (utils::packageVersion("readr") > "1.4.0") {
   c(csv   = readr::read_csv,
     csv2  = readr::read_csv2,
     table = readr::read_table)[fun]
-  } else {
-    c(csv   = readr::read_csv,
-      csv2  = readr::read_csv2,
-      table = readr::read_table2)[fun]
-  }
 }
 
 


### PR DESCRIPTION
The `read_table2()` function will be removed in the next release of readr. It has been deprecated for over 4 years, since readr v2.0.0 (2021-07-20). Since that time, it has just been aliased to `read_table()` anyway. This PR removes explicit handling for readr <2.0.0, which seems like a reasonable approach, but you may have another solution.

This is part of a bigger effort to advance a bunch of deprecation processes that started 4+ years ago: https://github.com/tidyverse/readr/issues/1600. I released readr v2.1.6 on 2025-11-14 and have no immediate plans for another release. I just wanted to advance these deprecations right away, to give downstream dependencies plenty of time to adjust.

I am also sending an email to the maintainer listed in DESCRIPTION.